### PR TITLE
Use 1st party cookies

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -13,6 +13,7 @@ services:
       SESSION_COOKIE_SECURE: "true"
       # share cookies between domains
       SESSION_COOKIE_SAMESITE: None
+      SESSION_COOKIE_DOMAIN: ${BASE_DOMAIN}
 
       # ultimate destination after SoF launch and backend auth
       LAUNCH_DEST: 'https://summary.${BASE_DOMAIN:-localtest.me}/launch.html'

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -11,8 +11,7 @@ services:
 
       PREFERRED_URL_SCHEME: https
       SESSION_COOKIE_SECURE: "true"
-      # share cookies between domains
-      SESSION_COOKIE_SAMESITE: None
+      # to share cookies between subdomains, set cookie domain to base domain of deploy
       SESSION_COOKIE_DOMAIN: ${BASE_DOMAIN}
 
       # ultimate destination after SoF launch and backend auth


### PR DESCRIPTION
- Set cookie domain to base domain of deploy
- Remove 3rd party cookie attribute

[See](https://github.com/uwcirg/helloworld-confidential-client-sof/pull/15)