### PR TITLE
fhir log volume

### DIFF
--- a/dev/confidentialbackend.env.default
+++ b/dev/confidentialbackend.env.default
@@ -5,6 +5,9 @@
 # Variables defined in this file will only be available to containers/images
 # ie not for interpolation in docker-compose YAML files
 
+# When defined, all upstream FHIR responses hit given logfile
+#FHIR_RESOURCES_LOGFILE=/var/log/confidentialbackend/fhir-response.log
+
 # JWT with embedded secret to match PGRST_JWT_SECRET from logs.env
 LOGSERVER_TOKEN=
 

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -34,7 +34,7 @@ services:
     depends_on:
       - redis
     volumes:
-      - "log-files:/var/log/confidentialbackend"
+      - log-files:/var/log/confidentialbackend
 
 
   db:
@@ -43,9 +43,9 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
     volumes:
-      - "db-data:/var/lib/postgresql/data"
+      - db-data:/var/lib/postgresql/data
       # mount db creation script in place for bootstrap
-      - "./config/db:/docker-entrypoint-initdb.d"
+      - ./config/db:/docker-entrypoint-initdb.d
     networks:
       - internal
 

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -33,6 +33,8 @@ services:
       - internal
     depends_on:
       - redis
+    volumes:
+      - "log-files:/var/log/confidentialbackend"
 
 
   db:
@@ -93,6 +95,7 @@ services:
 
 volumes:
   db-data: {}
+  log-files: {}
 
 
 networks:


### PR DESCRIPTION
simply add a volume for the fhir-response logs, so the log file isn't ephemeral and will survive container restarts.

@ivan-c is there a mechanism to pull the path of the volume into the `FHIR_RESOURCES_LOGFILE` variable?