### PR TITLE
Cookie settings for iframe launches

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -11,6 +11,9 @@ services:
 
       PREFERRED_URL_SCHEME: https
       SESSION_COOKIE_SECURE: "true"
+      # required for setting cookies in cross-site iframes (eg Epic Hyperdrive)
+      SESSION_COOKIE_PARTITIONED: "true"
+      SESSION_COOKIE_SAMESITE: "None"
       # ultimate destination after SoF launch and backend auth
       LAUNCH_DEST: 'https://confidentialbackend.${BASE_DOMAIN:-localtest.me}/launch.html'
 

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -12,7 +12,6 @@ services:
       PREFERRED_URL_SCHEME: https
       SESSION_COOKIE_SECURE: "true"
       # required for setting cookies in cross-site iframes (eg Epic Hyperdrive)
-      SESSION_COOKIE_PARTITIONED: "true"
       SESSION_COOKIE_SAMESITE: "None"
       # ultimate destination after SoF launch and backend auth
       LAUNCH_DEST: 'https://confidentialbackend.${BASE_DOMAIN:-localtest.me}/launch.html'

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -19,8 +19,7 @@ services:
 
       # do not pass launch/patient as Epic will infer standalone launch
       SOF_CLIENT_SCOPES: "user/*.read launch openid fhirUser"
-      SOF_ACCESS_TOKEN_URL: 'https://keycloak.${BASE_DOMAIN:-localtest.me}/auth/realms/fEMR/protocol/openid-connect/token'
-      SOF_AUTHORIZE_URL: 'https://keycloak.${BASE_DOMAIN:-localtest.me}/auth/realms/fEMR/protocol/openid-connect/auth'
+
       LOGSERVER_URL: "https://logs.${BASE_DOMAIN:-localtest.me}"
     labels:
       - "traefik.enable=true"

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -11,9 +11,6 @@ services:
 
       PREFERRED_URL_SCHEME: https
       SESSION_COOKIE_SECURE: "true"
-      # to share cookies between subdomains, set cookie domain to base domain of deploy
-      SESSION_COOKIE_DOMAIN: ${BASE_DOMAIN}
-
       # ultimate destination after SoF launch and backend auth
       LAUNCH_DEST: 'https://confidentialbackend.${BASE_DOMAIN:-localtest.me}/launch.html'
 


### PR DESCRIPTION
- Remove old settings for sharing cookies across summary/confidentialbackend domain
- Set `SameSite: None` for iframe SoF launches