### PR TITLE
DRY Hapi FHIR config

### DIFF
--- a/base/docker-compose.yaml
+++ b/base/docker-compose.yaml
@@ -144,7 +144,11 @@ services:
       # mount db creation script in place for bootstrap
       - ./config/db:/docker-entrypoint-initdb.d
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U postgres -d hapifhir"]
+      test:
+        - CMD
+        - pg_isready
+        - --user=postgres
+        - --dbname=hapifhir
       interval: 5s
       timeout: 5s
       retries: 10


### PR DESCRIPTION
- Remove erroneous dev config leftover in base/ from earlier refactor: #16
- Fixup port issue: use default container port Hapi listens on
- Move common Hapi config to `fhir-base`
- Rewrite postgres healthcheck in exec format (from shell), use long-options