### PR TITLE
Secure logserver, Refactor un/authenticated routes

### DIFF
--- a/base/docker-compose.yaml
+++ b/base/docker-compose.yaml
@@ -105,6 +105,15 @@ services:
       internal:
         aliases:
           - fhir-internal
+    labels:
+      - traefik.enable=true
+      # authenticated route
+      - traefik.http.routers.fhir-auth-${COMPOSE_PROJECT_NAME}.rule=Host(`fhir-auth.${BASE_DOMAIN}`)
+      - traefik.http.routers.fhir-auth-${COMPOSE_PROJECT_NAME}.entrypoints=websecure
+      - traefik.http.routers.fhir-auth-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt
+      - traefik.http.routers.fhir-auth-${COMPOSE_PROJECT_NAME}.middlewares=fhir-auth-${COMPOSE_PROJECT_NAME}
+      # require password; see .env
+      - traefik.http.middlewares.fhir-auth-${COMPOSE_PROJECT_NAME}.basicauth.users=admin:${FHIR_AUTH_PASSWORD_HASH}
 
   launchcache:
     extends:

--- a/base/docker-compose.yaml
+++ b/base/docker-compose.yaml
@@ -120,12 +120,6 @@ services:
 
   logs:
     image: postgrest/postgrest
-    labels:
-      - traefik.enable=true
-      - traefik.http.routers.logs-${COMPOSE_PROJECT_NAME}.rule=Host(`logs.${BASE_DOMAIN}`)
-      - traefik.http.routers.logs-${COMPOSE_PROJECT_NAME}.entrypoints=websecure
-      - traefik.http.routers.logs-${COMPOSE_PROJECT_NAME}.tls=true
-      - traefik.http.routers.logs-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt
     environment:
       PGRST_DB_URI: postgres://postgres:postgres@db:5432/app_db
       PGRST_DB_SCHEMA: api
@@ -136,6 +130,8 @@ services:
     networks:
       - ingress
       - internal
+    labels:
+      - traefik.enable=true
 
   db:
     image: postgres:${POSTGRES_IMAGE_TAG:-17}

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -35,14 +35,6 @@ services:
       - traefik.http.routers.fhir-${COMPOSE_PROJECT_NAME}.entrypoints=websecure
       - traefik.http.routers.fhir-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt
 
-      # authenticated route
-      - traefik.http.routers.fhir-auth-${COMPOSE_PROJECT_NAME}.rule=Host(`fhir-auth.${BASE_DOMAIN}`)
-      - traefik.http.routers.fhir-auth-${COMPOSE_PROJECT_NAME}.entrypoints=websecure
-      - traefik.http.routers.fhir-auth-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt
-      - traefik.http.routers.fhir-auth-${COMPOSE_PROJECT_NAME}.middlewares=fhir-auth-${COMPOSE_PROJECT_NAME}
-      # require password; see .env
-      - traefik.http.middlewares.fhir-auth-${COMPOSE_PROJECT_NAME}.basicauth.users=admin:${FHIR_AUTH_PASSWORD_HASH}
-
   launchcache:
     extends:
       file: ../base/docker-compose.yaml

--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -63,6 +63,11 @@ services:
       service: logs
     env_file:
       - logs.env
+    labels:
+      - traefik.http.routers.logs-${COMPOSE_PROJECT_NAME}.rule=Host(`logs.${BASE_DOMAIN}`)
+      - traefik.http.routers.logs-${COMPOSE_PROJECT_NAME}.entrypoints=websecure
+      - traefik.http.routers.logs-${COMPOSE_PROJECT_NAME}.tls=true
+      - traefik.http.routers.logs-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt
 
   db:
     extends:

--- a/prod/docker-compose.yaml
+++ b/prod/docker-compose.yaml
@@ -33,7 +33,7 @@ services:
     env_file:
       - logs.env
     labels:
-      # Allow POST /events WITHOUT auth
+      # Allow POST /events WITHOUT auth: PostgREST manages auth
       - traefik.http.routers.logs-events-${COMPOSE_PROJECT_NAME}.rule=Host(`logs.${BASE_DOMAIN}`) && Path(`/events`) && Method(`POST`)
       - traefik.http.routers.logs-events-${COMPOSE_PROJECT_NAME}.entrypoints=websecure
       - traefik.http.routers.logs-events-${COMPOSE_PROJECT_NAME}.tls=true

--- a/prod/docker-compose.yaml
+++ b/prod/docker-compose.yaml
@@ -32,7 +32,24 @@ services:
       service: logs
     env_file:
       - logs.env
+    labels:
+      # Allow POST /events WITHOUT auth
+      - traefik.http.routers.logs-events-${COMPOSE_PROJECT_NAME}.rule=Host(`logs.${BASE_DOMAIN}`) && Path(`/events`) && Method(`POST`)
+      - traefik.http.routers.logs-events-${COMPOSE_PROJECT_NAME}.entrypoints=websecure
+      - traefik.http.routers.logs-events-${COMPOSE_PROJECT_NAME}.tls=true
+      - traefik.http.routers.logs-events-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt
+      - traefik.http.routers.logs-events-${COMPOSE_PROJECT_NAME}.priority=100
 
+      # Require auth for all other requests
+      - traefik.http.routers.logs-${COMPOSE_PROJECT_NAME}.rule=Host(`logs.${BASE_DOMAIN}`)
+      - traefik.http.routers.logs-${COMPOSE_PROJECT_NAME}.entrypoints=websecure
+      - traefik.http.routers.logs-${COMPOSE_PROJECT_NAME}.tls=true
+      - traefik.http.routers.logs-${COMPOSE_PROJECT_NAME}.tls.certresolver=letsencrypt
+      - traefik.http.routers.logs-${COMPOSE_PROJECT_NAME}.middlewares=logs-auth-${COMPOSE_PROJECT_NAME}
+
+      # Basic auth middleware
+      # requires password; see .env
+      - traefik.http.middlewares.logs-auth-${COMPOSE_PROJECT_NAME}.basicauth.users=admin:${LOGS_PASSWORD_HASH}
   db:
     extends:
       file: ../base/docker-compose.yaml

--- a/prod/docker-compose.yaml
+++ b/prod/docker-compose.yaml
@@ -26,6 +26,11 @@ services:
       file: ../base/docker-compose.yaml
       service: fhir
 
+  launchcache:
+    extends:
+      file: ../base/docker-compose.yaml
+      service: launchcache
+
   logs:
     extends:
       file: ../base/docker-compose.yaml


### PR DESCRIPTION
- Refactor un/authenticated routes
  - Move authenticated FHIR route to base
  - Move unauthenticated logs route to dev
- Add authenticated logs route, secured with BASIC auth
